### PR TITLE
13 카카오 로그인회원가입

### DIFF
--- a/inear/.gitignore
+++ b/inear/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ##
 application-prod.yml
+/src/main/java/com/inear/inear/config/Secret.java

--- a/inear/build.gradle
+++ b/inear/build.gradle
@@ -31,6 +31,12 @@ dependencies {
 	implementation 'com.oracle.database.security:oraclepki'
 	implementation 'com.oracle.database.security:osdt_core'
 	implementation 'com.oracle.database.security:osdt_cert'
+
+	//json
+	implementation 'com.google.code.gson:gson'
+
+	//jwt
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 }
 
 tasks.named('test') {

--- a/inear/src/main/java/com/inear/inear/controller/UserController.java
+++ b/inear/src/main/java/com/inear/inear/controller/UserController.java
@@ -1,0 +1,37 @@
+package com.inear.inear.controller;
+
+import com.inear.inear.controller.model.CheckJwtRes;
+import com.inear.inear.controller.model.PostKakaoSignUpAndSignInReq;
+import com.inear.inear.controller.model.PostKakaoSignUpAndSignInRes;
+import com.inear.inear.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.apache.catalina.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/login/kakao")
+    public ResponseEntity<PostKakaoSignUpAndSignInRes> postKakaoSignUpAndSignIn(PostKakaoSignUpAndSignInReq postKakaoSignUpAndSignInReq) throws IOException {
+
+        PostKakaoSignUpAndSignInRes postKakaoSignUpAndSignInRes = userService.kakaoSignUpAndSignIn(postKakaoSignUpAndSignInReq);
+
+        return new ResponseEntity(postKakaoSignUpAndSignInRes, HttpStatus.OK);
+    }
+
+    @GetMapping("/check/jwt")
+    public ResponseEntity<CheckJwtRes> getJwt() {
+
+        return new ResponseEntity(userService.checkJwt(), HttpStatus.OK);
+    }
+}

--- a/inear/src/main/java/com/inear/inear/controller/model/CheckJwtRes.java
+++ b/inear/src/main/java/com/inear/inear/controller/model/CheckJwtRes.java
@@ -1,0 +1,13 @@
+package com.inear.inear.controller.model;
+
+import lombok.Data;
+
+@Data
+public class CheckJwtRes {
+
+    public CheckJwtRes(boolean isSuccess) {
+        this.isSuccess = isSuccess;
+    }
+
+    private boolean isSuccess;
+}

--- a/inear/src/main/java/com/inear/inear/controller/model/PostKakaoSignUpAndSignInReq.java
+++ b/inear/src/main/java/com/inear/inear/controller/model/PostKakaoSignUpAndSignInReq.java
@@ -1,0 +1,8 @@
+package com.inear.inear.controller.model;
+
+import lombok.Data;
+
+@Data
+public class PostKakaoSignUpAndSignInReq {
+    private String accessToken;
+}

--- a/inear/src/main/java/com/inear/inear/controller/model/PostKakaoSignUpAndSignInRes.java
+++ b/inear/src/main/java/com/inear/inear/controller/model/PostKakaoSignUpAndSignInRes.java
@@ -1,0 +1,10 @@
+package com.inear.inear.controller.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class PostKakaoSignUpAndSignInRes {
+    private String jwt;
+}

--- a/inear/src/main/java/com/inear/inear/exception/JwtException.java
+++ b/inear/src/main/java/com/inear/inear/exception/JwtException.java
@@ -1,0 +1,14 @@
+package com.inear.inear.exception;
+
+import javax.management.RuntimeErrorException;
+
+public class JwtException extends RuntimeErrorException {
+
+    public JwtException(Error e) {
+        super(e);
+    }
+
+    public JwtException(Error e, String message) {
+        super(e, message);
+    }
+}

--- a/inear/src/main/java/com/inear/inear/model/Alarm.java
+++ b/inear/src/main/java/com/inear/inear/model/Alarm.java
@@ -1,0 +1,40 @@
+package com.inear.inear.model;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name="Alarm")
+public class Alarm {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "alarm_id")
+    private Long alarmId;
+
+    @ManyToOne
+    @JoinColumn(name="user_id")
+    private Users userID;
+
+    @Column(name = "alarm_time")
+    private LocalDateTime alarmTime;
+
+    @Column(name = "alarmDate")
+    private String alarmDate;
+
+    @Column(name = "repeat")
+    private int repeat;
+
+    @Column(name = "term")
+    private int term;
+
+    @Column(name = "voice_type")
+    private int voiceType;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "message")
+    private String message;
+
+}

--- a/inear/src/main/java/com/inear/inear/model/Alarm.java
+++ b/inear/src/main/java/com/inear/inear/model/Alarm.java
@@ -37,4 +37,7 @@ public class Alarm {
     @Column(name = "message")
     private String message;
 
+    @Column(name = "path")
+    private String path;
+
 }

--- a/inear/src/main/java/com/inear/inear/model/Alarm.java
+++ b/inear/src/main/java/com/inear/inear/model/Alarm.java
@@ -29,7 +29,7 @@ public class Alarm {
     private int term;
 
     @Column(name = "voice_type")
-    private int voiceType;
+    private String voiceType;
 
     @Column(name = "name")
     private String name;

--- a/inear/src/main/java/com/inear/inear/model/Users.java
+++ b/inear/src/main/java/com/inear/inear/model/Users.java
@@ -1,10 +1,20 @@
 package com.inear.inear.model;
 
+import lombok.Getter;
+
 import javax.persistence.*;
 
 @Entity
 @Table(name="users")
+@Getter
 public class Users {
+
+    public Users() {
+    }
+
+    public Users(String snsId) {
+        this.snsId = snsId;
+    }
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
@@ -13,5 +23,6 @@ public class Users {
 
     @Column(name = "sns_id")
     private String snsId;
+
 
 }

--- a/inear/src/main/java/com/inear/inear/model/Users.java
+++ b/inear/src/main/java/com/inear/inear/model/Users.java
@@ -1,0 +1,17 @@
+package com.inear.inear.model;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name="users")
+public class Users {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "sns_id")
+    private String snsId;
+
+}

--- a/inear/src/main/java/com/inear/inear/repository/UserRepository.java
+++ b/inear/src/main/java/com/inear/inear/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.inear.inear.repository;
+
+import com.inear.inear.model.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<Users,Long> {
+
+    Users findBySnsId(String snsId);
+
+}

--- a/inear/src/main/java/com/inear/inear/service/JwtService.java
+++ b/inear/src/main/java/com/inear/inear/service/JwtService.java
@@ -1,0 +1,56 @@
+package com.inear.inear.service;
+
+import io.jsonwebtoken.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Date;
+
+import static com.inear.inear.config.Secret.JWT_SECRET_KEY;
+
+@Service
+public class JwtService {
+
+    private static final String X_ACCESS_TOKEN = "X-ACCESS-TOKEN";
+    private static final String USER_ID = "userId";
+    private static final String EMPTY_JWT_ERROR = "JWT를 입력해주세요";
+    private static final String INVALID_JWT = "유효하지 않은 JWT : ";
+
+    public String createJwt(Long userId) {
+        Date now = new Date();
+        return Jwts.builder()
+                .claim(USER_ID, userId)
+                .setIssuedAt(now)
+                .signWith(SignatureAlgorithm.HS256, JWT_SECRET_KEY)
+                .compact();
+    }
+
+    public String getJwt() {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        return request.getHeader(X_ACCESS_TOKEN);
+    }
+
+    public Long getUserId() throws JwtException {
+
+        String accessToken = getJwt();
+        if (accessToken == null || accessToken.length() == 0) {
+            throw new JwtException(EMPTY_JWT_ERROR);
+        }
+
+        Jws<Claims> claims;
+        try {
+            claims = Jwts.parser()
+                    .setSigningKey(JWT_SECRET_KEY)
+                    .parseClaimsJws(accessToken);
+        } catch (Exception ignored) {
+            throw new JwtException(INVALID_JWT  + accessToken);
+        }
+
+        Long userId = Long.valueOf(claims.getBody().get(USER_ID, Integer.class));
+
+        return userId;
+    }
+
+}

--- a/inear/src/main/java/com/inear/inear/service/KakaoAccessToken.java
+++ b/inear/src/main/java/com/inear/inear/service/KakaoAccessToken.java
@@ -17,7 +17,7 @@ import java.io.BufferedReader;
 public class KakaoAccessToken {
 
     private final String accessToken;
-    private final String KAKAO_USER_INFO_API = "https://kapi.kakao.com/v2/user/me";
+    private static final String KAKAO_USER_INFO_API = "https://kapi.kakao.com/v2/user/me";
 
     public KakaoAccessToken(String accessToken) {
         this.accessToken = accessToken;

--- a/inear/src/main/java/com/inear/inear/service/KakaoAccessToken.java
+++ b/inear/src/main/java/com/inear/inear/service/KakaoAccessToken.java
@@ -1,0 +1,47 @@
+package com.inear.inear.service;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
+import java.io.*;
+import java.net.*;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.io.BufferedReader;
+
+
+public class KakaoAccessToken {
+
+    private final String accessToken;
+    private final String KAKAO_USER_INFO_API = "https://kapi.kakao.com/v2/user/me";
+
+    public KakaoAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getSnsId() throws IOException {
+        URL url = new URL(KAKAO_USER_INFO_API);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+
+        //    요청에 필요한 Header에 포함될 내용
+        conn.setRequestProperty("Authorization", "Bearer " + accessToken);
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+
+        String line = "";
+        String result = "";
+
+        while ((line = br.readLine()) != null) {
+            result += line;
+        }
+
+        JsonElement jsonElement = JsonParser.parseString(result);
+
+        return jsonElement.getAsJsonObject().get("id").getAsString();
+    }
+}

--- a/inear/src/main/java/com/inear/inear/service/UserService.java
+++ b/inear/src/main/java/com/inear/inear/service/UserService.java
@@ -1,0 +1,58 @@
+package com.inear.inear.service;
+
+
+
+import com.inear.inear.controller.model.CheckJwtRes;
+import com.inear.inear.controller.model.PostKakaoSignUpAndSignInReq;
+import com.inear.inear.controller.model.PostKakaoSignUpAndSignInRes;
+import com.inear.inear.model.Users;
+import com.inear.inear.repository.UserRepository;
+import io.jsonwebtoken.JwtException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final JwtService jwtService;
+
+    public PostKakaoSignUpAndSignInRes kakaoSignUpAndSignIn(PostKakaoSignUpAndSignInReq postKakaoSignUpAndSignInReq) throws IOException {
+
+        KakaoAccessToken accessToken = new KakaoAccessToken(postKakaoSignUpAndSignInReq.getAccessToken());
+
+        return getPostKakaoSignUpAndSignInRes(accessToken.getSnsId());
+    }
+
+    private PostKakaoSignUpAndSignInRes getPostKakaoSignUpAndSignInRes(String snsId) {
+        Users user = getSnsIdInDB(snsId);
+        if(user != null){
+            return new PostKakaoSignUpAndSignInRes(jwtService.createJwt(user.getUserId()));
+        }
+        return new PostKakaoSignUpAndSignInRes(jwtService.createJwt(userRepository.save(new Users(snsId)).getUserId()));
+    }
+
+    private Users getSnsIdInDB(String snsId) {
+        return userRepository.findBySnsId(snsId);
+    }
+
+    public CheckJwtRes checkJwt() {
+        try{
+            jwtService.getUserId();
+            return new CheckJwtRes(true);
+        } catch (JwtException e) {
+            log.info(e.getMessage());
+            return new CheckJwtRes(false);
+        }
+    }
+}


### PR DESCRIPTION
- 자동 로그인 api
- 카카오 회원가입
- 카카오 로그인

자동 로그인 로직
- 앱 실행시 자동 로그인 api 호출
- jwt가 유효한지 여부 리턴
- 유효하다면 그대로 로그인, 유요하지 않다면 로그인 화면

카카오 로그인/회원가입 로직
- 카카오 로그인 (클라가 access token 전달)
- accesstoken 을 카카오서버에 전송해 snsid값을 가져옴
- snsid로 DB Users 테이블 조회시 이미 있다면 이미 회원가입한 유저임. db의 userid값을 받아와 jwt 토큰으로 만들어 리턴
- snsid로 조회시 없다면 DB에 insert 하고 userid값을 받아와 jwt토크으로 만들어 리턴

